### PR TITLE
Change doc url on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a drop-in provider for [apnscp](https://apnscp.com) to enable DNS suppor
 EditDomain -c dns,provider=linode -c dns,key=abcdef1234567890 domain.com
 ```
 
-Where the key is created within Linode. See Linode: [API Key](https://www.linode.com/docs/platform/api/api-key/) for information.
+Where the key is created within Linode. See Linode: [API Key](https://www.linode.com/docs/platform/api/getting-started-with-the-linode-api/) for information.
 
 ## Components
 


### PR DESCRIPTION
This updates the URL on [README.md](https://github.com/apisnetworks/apnscp-dns-linode/blob/master/README.md) to Linode's Documentation for getting an API key to our v4 documentation. The process for acquiring a token has changed with v4 of our API.

https://github.com/apisnetworks/apnscp-dns-linode/blob/43b31f4eb90446de9f642d8139a2b260b7c364c7/Api.php#L17